### PR TITLE
Potential fix for code scanning alert no. 194: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -33,7 +33,7 @@ export function showProductReviews () {
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/M365x74358153/juice-shop/security/code-scanning/194](https://github.com/M365x74358153/juice-shop/security/code-scanning/194)

The best way to fix this problem is to avoid passing user input to the `$where` operator entirely. Instead, use standard MongoDB queries, which do not evaluate user input as code and thus are safe from code injection. Specifically, for this scenario, we should query with `{ product: id }` (where id is parsed as an integer if required). If there is an application reason for allowing non-integer product ids, we can use `{ product: id }` directly. If the challenge "noSqlCommandChallenge" is enabled and we need to accept string ids, ensure that the user input is not passed to `$where`.  

All changes should occur in routes/showProductReviews.ts. On line 36, replace the use of `$where: 'this.product == ' + id` with `{ product: id }`. Ensure that `id` is the same type as used for product ids in the database (likely a number, but if not, use as is). If the intent is to keep the challenge logic as-is, preserve it as a code comment, but never use `$where` with user input.

No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
